### PR TITLE
Enable oauth_version parameter to be "1.0", "1.0a" or not sent

### DIFF
--- a/src/Helpers/Constants.cs
+++ b/src/Helpers/Constants.cs
@@ -18,6 +18,7 @@ namespace OAuth
         internal const string oauth_version = "oauth_version";
         internal const string oauth_callback = "oauth_callback";
         internal const string oauth_verifier = "oauth_verifier";
+        internal const string oauth_version_1 = "1.0";
         internal const string oauth_version_1a = "1.0a";
         internal const string OAuthAuthenticationHeader = "OAuth";
     }

--- a/src/OAuthAuthenticator.cs
+++ b/src/OAuthAuthenticator.cs
@@ -14,10 +14,25 @@ namespace OAuth
     {
         private readonly string _apiKey;
         private readonly string _secret;
-        public OAuthAuthenticator(string apiKey, string secret)
+        private readonly string _versionParameter;
+
+        public OAuthAuthenticator(string apiKey, string secret, OAuthVersionParameter versionParameter = OAuthVersionParameter.OneZeroA)
         {
             _apiKey = apiKey;
             _secret = secret;
+            switch (versionParameter)
+            {
+                case OAuthVersionParameter.OneZeroA:
+                    _versionParameter = Constants.oauth_version_1a;
+                    break;
+                case OAuthVersionParameter.OneZero:
+                    _versionParameter = Constants.oauth_version_1;
+                    break;
+                case OAuthVersionParameter.Omit:
+                default:
+                    _versionParameter = string.Empty;
+                    break;
+            }
         }
 
         private string CreateRequest(string url, string method, string tokSecret, params object[] args)
@@ -28,8 +43,12 @@ namespace OAuth
                 new KeyValuePair<string,string>(Constants.oauth_nonce, OAuthHelpers.GenerateNonce() ),
                 new KeyValuePair<string,string>(Constants.oauth_timestamp, OAuthHelpers.GenerateTimestamp() ),
                 new KeyValuePair<string,string>(Constants.oauth_signature_method, "HMAC-SHA1"),
-                new KeyValuePair<string,string>(Constants.oauth_version, Constants.oauth_version_1a),
             };
+
+            if (!string.IsNullOrEmpty(_versionParameter))
+            {
+                parameters.Add(new KeyValuePair<string, string>(Constants.oauth_version, _versionParameter));
+            }
 
             for (int i = 0; i < args.Length; i += 2)
             {

--- a/src/OAuthMessageHandler.cs
+++ b/src/OAuthMessageHandler.cs
@@ -13,13 +13,27 @@ namespace OAuth
         private readonly string _secret;
         private readonly string _authToken;
         private readonly string _authTokenSecret;
+        private readonly string _versionParameter;
 
-        public OAuthMessageHandler(string apiKey, string secret, string authToken, string authTokenSecret)
+        public OAuthMessageHandler(string apiKey, string secret, string authToken, string authTokenSecret, OAuthVersionParameter versionParameter = OAuthVersionParameter.OneZeroA)
         {
             _apiKey = apiKey;
             _secret = secret;
             _authToken = authToken;
             _authTokenSecret = authTokenSecret;
+            switch (versionParameter)
+            {
+                case OAuthVersionParameter.OneZeroA:
+                    _versionParameter = Constants.oauth_version_1a;
+                    break;
+                case OAuthVersionParameter.OneZero:
+                    _versionParameter = Constants.oauth_version_1;
+                    break;
+                case OAuthVersionParameter.Omit:
+                default:
+                    _versionParameter = string.Empty;
+                    break;
+            }
 
             this.InnerHandler = new HttpClientHandler();
         }
@@ -35,9 +49,13 @@ namespace OAuth
                 new KeyValuePair<string,string>(Constants.oauth_nonce, OAuthHelpers.GenerateNonce() ),
                 new KeyValuePair<string,string>(Constants.oauth_timestamp, OAuthHelpers.GenerateTimestamp() ),
                 new KeyValuePair<string,string>(Constants.oauth_signature_method, "HMAC-SHA1"),
-                new KeyValuePair<string,string>(Constants.oauth_version, Constants.oauth_version_1a),
                 new KeyValuePair<string,string>(Constants.oauth_token, _authToken),
             };
+
+            if (!string.IsNullOrEmpty(_versionParameter))
+            {
+                parameters.Add(new KeyValuePair<string, string>(Constants.oauth_version, _versionParameter));
+            }
 
             string baseUri = requestUri.OriginalString;
 

--- a/src/OAuthVersionParameter.cs
+++ b/src/OAuthVersionParameter.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace OAuth
+{
+    public enum OAuthVersionParameter
+    {
+        Omit = 0,
+        OneZeroA,
+        OneZero
+    }
+}


### PR DESCRIPTION
Fixes #6 
I also added the option to not send "oauth_version" at all. I'm not sure why you wouldn't want to do that (maybe to save a few bytes) but the specification says the parameter is optional, so I thought I might as well add that option.