### PR TITLE
Expose the OAuth version via the interface that allows testing

### DIFF
--- a/src/OAuthMessageHandler.cs
+++ b/src/OAuthMessageHandler.cs
@@ -40,7 +40,7 @@ namespace OAuth
             _apiKeyParam = new KeyValuePair<string, string>(Constants.oauth_consumer_key, _apiKey);
             _authTokenParam = new KeyValuePair<string, string>(Constants.oauth_token, _authToken);
             // TODO: incorporate the other PR.
-            _oauthVersionParam = new KeyValuePair<string, string>(Constants.oauth_version, Constants.oauth_version_1a);
+            _oauthVersionParam = new KeyValuePair<string, string>(Constants.oauth_version, _provider.OAuthVersion());
 
             _keyBytes = OAuthHelpers.CreateHashKeyBytes(_secret, _authTokenSecret);
 

--- a/src/Provider/IOAuthRandomnessProvider.cs
+++ b/src/Provider/IOAuthRandomnessProvider.cs
@@ -4,5 +4,6 @@
     {
         string GenerateNonce();
         string GenerateTimeStamp();
+        string OAuthVersion();
     }
 }

--- a/src/Provider/OAuthProvider.cs
+++ b/src/Provider/OAuthProvider.cs
@@ -11,5 +11,10 @@
         {
             return OAuth.Helpers.OAuthHelpers.GenerateTimestamp();
         }
+
+        public string OAuthVersion()
+        {
+            return OAuth.Constants.oauth_version_1a;
+        }
     }
 }

--- a/test/TestHelper.cs
+++ b/test/TestHelper.cs
@@ -27,9 +27,9 @@ namespace OAuth.Net.Tests
         /// </summary>
         /// <param name="request"></param>
         /// <returns></returns>
-        public string ComputeOAuthSignature(HttpRequestMessage request, string nonce, string timestamp)
+        public string ComputeOAuthSignature(HttpRequestMessage request, string nonce, string timestamp, string oauthVersion="1.0a")
         {
-            OAuth.OAuthMessageHandler msgHandler = new OAuthMessageHandler(_apiKey, _secret, _authToken, _authTokenSecret, new TestOAuthProvider(nonce, timestamp));
+            OAuth.OAuthMessageHandler msgHandler = new OAuthMessageHandler(_apiKey, _secret, _authToken, _authTokenSecret, new TestOAuthProvider(nonce, timestamp, oauthVersion));
 
             // get access to the method.
 

--- a/test/TestOAuthProvider.cs
+++ b/test/TestOAuthProvider.cs
@@ -8,10 +8,12 @@ namespace OAuth.Net.Tests
     {
         string _nonce;
         string _timestamp;
-        public TestOAuthProvider(string nonce, string timestamp)
+        string _oauthVersion;
+        public TestOAuthProvider(string nonce, string timestamp, string version="1.0a")
         {
             _nonce = nonce;
-            _timestamp = timestamp; 
+            _timestamp = timestamp;
+            _oauthVersion = version;
         }
 
         public string GenerateNonce()
@@ -22,6 +24,11 @@ namespace OAuth.Net.Tests
         public string GenerateTimeStamp()
         {
             return _timestamp;
+        }
+
+        public string OAuthVersion()
+        {
+            return _oauthVersion;
         }
     }
 }

--- a/test/ValidateHeaderSignature.cs
+++ b/test/ValidateHeaderSignature.cs
@@ -91,5 +91,18 @@ namespace OAuth.Net.Tests
             Assert.Equal("0eQCtR89OhlUPIBqku8PobHIFQA%3D", result);
         }
 
+        [Fact]
+        public void ValidateSignaturePerSpecExample()
+        {
+            TestHelper th = new TestHelper("dpf43f3p2l4k3l03", "kd94hf93k423kf44", "nnch734d00sl2jdk", "pfkkdhi9sl3r4s00");
+            var result = th.ComputeOAuthSignature(
+                new HttpRequestMessage(
+                    HttpMethod.Get, 
+                    "http://photos.example.net/photos?file=vacation.jpg&size=original"),
+                "kllo9940pd9333jh", 
+                "1191242096",
+                "1.0"); // the spec example uses 1.0 as the OAuth version.
+            Assert.Equal("tR3%2BTy81lMeYAr%2FFid0kMTYa%2FWM%3D", result);
+        }
     }
 }


### PR DESCRIPTION
This allows testing of various protocol versions.

Added test for the canonical example of OAuth signature from the spec.